### PR TITLE
Serialization of superclasses

### DIFF
--- a/src/main/java/pl/maciejwalkowiak/plist/FieldSerializer.java
+++ b/src/main/java/pl/maciejwalkowiak/plist/FieldSerializer.java
@@ -34,6 +34,7 @@ import pl.maciejwalkowiak.plist.handler.PlistSerializationException;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +58,7 @@ public class FieldSerializer {
 
 	public String serializeFields(Object objectToConvert) {
 		StringBuilder result = new StringBuilder();
-		List<Field> fields = Arrays.asList(objectToConvert.getClass().getDeclaredFields());
+		List<Field> fields = getAllFields(objectToConvert.getClass());
 
 		Collections.sort(fields, fieldComparator);
 		for (Field field : fields) {
@@ -130,4 +131,12 @@ public class FieldSerializer {
 
 		return XMLHelper.wrap(keyToWrap).with("key");
 	}
+
+    private static List<Field> getAllFields(Class<?> type) {
+        List<Field> fields = new ArrayList<Field>();
+        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+            fields.addAll(Arrays.asList(c.getDeclaredFields()));
+        }
+        return fields;
+    }
 }

--- a/src/test/java/pl/maciejwalkowiak/plist/FooChild.java
+++ b/src/test/java/pl/maciejwalkowiak/plist/FooChild.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012 Maciej Walkowiak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package pl.maciejwalkowiak.plist;
+
+public class FooChild extends FooParent{
+	private String bar;
+
+	public FooChild(String foo, String bar) {
+		super(foo);
+		this.bar = bar;
+	}
+}

--- a/src/test/java/pl/maciejwalkowiak/plist/FooParent.java
+++ b/src/test/java/pl/maciejwalkowiak/plist/FooParent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012 Maciej Walkowiak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package pl.maciejwalkowiak.plist;
+
+public class FooParent {
+	private String foo;
+
+	public FooParent(String foo) {
+		this.foo = foo;
+	}
+}

--- a/src/test/java/pl/maciejwalkowiak/plist/PlistSerializerImplTest.java
+++ b/src/test/java/pl/maciejwalkowiak/plist/PlistSerializerImplTest.java
@@ -171,6 +171,19 @@ public class PlistSerializerImplTest {
 		//then
 		assertThat(xml).isEqualTo("<real>4.55</real>");
 	}
+	
+	@Test
+	public void testInheritedFieldsSerialization()
+	{
+		//given
+		FooChild object = new FooChild("test1", "test2");
+		
+		//when
+		String xml = plistSerializer.serialize(object);
+		
+		//then
+		assertThat(xml).isEqualTo("<dict><key>bar</key><string>test2</string><key>foo</key><string>test1</string></dict>");
+	}
 
 	@Test
 	public void testSupportedDataTypes() throws IllegalAccessException, InstantiationException {


### PR DESCRIPTION
Java plist serializer currently serialized only a class itself and it doesn't look for fields in hierarchy of superclasses of serialized class.

This pull request handles a scenario when serialized class have superclass with the information which needs to be serialized.
