### PR TITLE
Support of Plist data tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.apache.axis</groupId>
+			<artifactId>axis</artifactId>
+			<version>1.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>1.6.4</version>

--- a/src/main/java/pl/maciejwalkowiak/plist/handler/DataHandler.java
+++ b/src/main/java/pl/maciejwalkowiak/plist/handler/DataHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012 Maciej Walkowiak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package pl.maciejwalkowiak.plist.handler;
+
+import pl.maciejwalkowiak.plist.XMLHelper;
+import pl.maciejwalkowiak.plist.plistypes.PlistData;
+
+import org.apache.axis.encoding.Base64;;
+
+/**
+ * @author Victor Ronin
+ */
+public class DataHandler implements Handler {
+
+	public boolean supports(Object object) {
+		return object instanceof PlistData;
+	}
+
+	public String handle(Object object) {
+		return XMLHelper.wrap(Base64.encode(((PlistData)object).getData())).with("data");
+	}
+}

--- a/src/main/java/pl/maciejwalkowiak/plist/handler/HandlerWrapper.java
+++ b/src/main/java/pl/maciejwalkowiak/plist/handler/HandlerWrapper.java
@@ -45,6 +45,7 @@ public class HandlerWrapper {
 				new IntegerHandler(),
 				new DoubleHandler(),
 				new DateHandler(),
+				new DataHandler(),	
 				new CollectionHandler(plistSerializer)));
 	}
 

--- a/src/main/java/pl/maciejwalkowiak/plist/plisttypes/PlistData.java
+++ b/src/main/java/pl/maciejwalkowiak/plist/plisttypes/PlistData.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012 Maciej Walkowiak
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package pl.maciejwalkowiak.plist.plistypes;
+
+/**
+ * @author Victor Ronin
+ */
+public class PlistData {
+	
+	private byte[] data;
+	
+	public PlistData(byte[] data)
+	{
+		this.data = data;
+	}
+	
+	public byte[] getData()
+	{
+		return data;
+	}
+}

--- a/src/test/java/pl/maciejwalkowiak/plist/PlistSerializerImplTest.java
+++ b/src/test/java/pl/maciejwalkowiak/plist/PlistSerializerImplTest.java
@@ -25,6 +25,7 @@ package pl.maciejwalkowiak.plist;
 import org.junit.Test;
 import pl.maciejwalkowiak.plist.handler.Handler;
 import pl.maciejwalkowiak.plist.strategy.UppercaseNamingStrategy;
+import pl.maciejwalkowiak.plist.plistypes.PlistData;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -171,6 +172,20 @@ public class PlistSerializerImplTest {
 		//then
 		assertThat(xml).isEqualTo("<real>4.55</real>");
 	}
+	
+	@Test
+	public void testPlistDataSerializationHandler()
+	{
+		//given
+		byte[] data = new String("test").getBytes();
+		PlistData object = new PlistData(data);
+
+		//when
+		String xml = plistSerializer.serialize(object);
+
+		//then
+		assertThat(xml).isEqualTo("<data>dGVzdA==</data>");
+	}	
 
 	@Test
 	public void testSupportedDataTypes() throws IllegalAccessException, InstantiationException {


### PR DESCRIPTION
Plist has a data tag. Generally speaking, it converts byte[] data to <data>base64(data)</data>

Taking into account that type byte[] is taken by CollectionHandler, I had to introduce new class to wrap byte[] and add PlistData
