### PR TITLE
Escape strings in XML payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
 			<version>${spring.version}</version>
 			<scope>compile</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+            <scope>compile</scope>
+        </dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -129,5 +135,5 @@
 			<version>1.9.0</version>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+    </dependencies>
 </project>

--- a/src/main/java/pl/maciejwalkowiak/plist/handler/StringHandler.java
+++ b/src/main/java/pl/maciejwalkowiak/plist/handler/StringHandler.java
@@ -22,6 +22,8 @@
 
 package pl.maciejwalkowiak.plist.handler;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 /**
  * @author Maciej Walkowiak
  */
@@ -29,6 +31,16 @@ public class StringHandler extends SimpleHandler {
 	public boolean supports(Object object) {
 		return object instanceof String;
 	}
+
+    @Override
+    public String handle(Object object) {
+        if(supports(object)) {
+            String escaped = StringEscapeUtils.escapeXml((String)object);
+            return super.handle(escaped);
+        } else {
+            throw new ObjectNotSupportedException("Handler does not support: " + object);
+        }
+    }
 
 	@Override
 	protected String getWrap() {

--- a/src/test/java/pl/maciejwalkowiak/plist/handler/StringHandlerTest.java
+++ b/src/test/java/pl/maciejwalkowiak/plist/handler/StringHandlerTest.java
@@ -1,0 +1,63 @@
+package pl.maciejwalkowiak.plist.handler;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.junit.Test;
+
+import java.text.ParseException;
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Created by nkhan on 4/9/15.
+ */
+public class StringHandlerTest {
+    private StringHandler stringHandler = new StringHandler();
+
+    @Test
+    public void testFormattingSimpleString() throws ParseException {
+        //given
+        String simpleString = "data1";
+
+        //when
+        String formattedString = stringHandler.handle(simpleString);
+
+        //then
+        assertThat(formattedString).isEqualTo("<string>data1</string>");
+    }
+
+    @Test
+       public void testFormattingWithSpecialCharsString1() throws ParseException {
+        //given a string with chars that need to be escaped
+        String stringWithSpecialChars = "sugar&spice";
+
+        //when
+        String formattedString = stringHandler.handle(stringWithSpecialChars);
+
+        //then
+        assertThat(formattedString).isEqualTo("<string>sugar&amp;spice</string>");
+    }
+
+    @Test
+    public void testFormattingWithSpecialCharsString2() throws ParseException {
+        //given a string with chars that need to be escaped
+        String stringWithSpecialChars = "<escapeme>";
+
+        //when
+        String formattedString = stringHandler.handle(stringWithSpecialChars);
+
+        //then
+        assertThat(formattedString).isEqualTo("<string>&lt;escapeme&gt;</string>");
+    }
+
+    @Test
+    public void testFormattingWithSpecialCharsString3() throws ParseException {
+        //given a string with chars that need to be escaped
+        String stringWithSpecialChars = "'quoteme'";
+
+        //when
+        String formattedString = stringHandler.handle(stringWithSpecialChars);
+
+        //then
+        assertThat(formattedString).isEqualTo("<string>&apos;quoteme&apos;</string>");
+    }
+
+}


### PR DESCRIPTION
The strings in your xml payloads are not escaped which cause deserialization errors if they have characters such as &, >, <, ", ' in them.

This PR will address that by escaping them using a third-party escaping api.

Unit tests are also included.

@maciejwalkowiak, let me know what you think?
